### PR TITLE
Download wkhtmltopdf package based on Heroku stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,5 @@ $ heroku plugins:install https://github.com/heroku/heroku-repo.git
 $ heroku repo:purge_cache -a appname
 ```
 
-## Troubleshooting
-
-If you run into issues when trying to deploy with this buildpack, make sure your app is running on Cedar with Ubuntu 14.04 (`cedar-14`). You can check this with:
-
-```bash
-$ heroku stack
-```
-
-If you are on an older stack, you can upgrade to `cedar-14` with:
-
-```bash
-$ heroku stack:set cedar-14
-```
-
 [0]: http://devcenter.heroku.com/articles/buildpacks
 [1]: http://wkhtmltopdf.org/

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,15 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
                  
-WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb"
+if [ "$STACK" == "cedar-14" ]; then
+  UBUNTU_VERSION="trusty"
+elif [ "$STACK" == "heroku-16" ]; then
+  UBUNTU_VERSION="xenial"
+else
+  UBUNTU_VERSION="bionic"
+fi
+
+WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${UBUNTU_VERSION}_amd64.deb"
 WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf.deb"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
@@ -21,7 +29,7 @@ FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 if [ -f $WKHTMLTOPDF_PKG ]; then
   echo "-----> Using wkhtmltopdf Debian package from cache"
 else
-  echo "-----> Downloading wkhtmltopdf Debian package"
+  echo "-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL}"
   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 fi
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# This buildpack is valid only for the cedar-14 stack
 if [ "$STACK" = "cedar-14" ] || [ "$STACK" = "heroku-16" ] || [ "$STACK" = "heroku-18" ]; then
   echo "wkhtmltopdf-buildpack"
   exit 0


### PR DESCRIPTION
This pull request fixes `wkhtmltopdf` usage on all current Heroku stacks.